### PR TITLE
Notify users their postal address might be altered.

### DIFF
--- a/View/Emails/text/imported_users-admin_update_users-user_updated.ctp
+++ b/View/Emails/text/imported_users-admin_update_users-user_updated.ctp
@@ -9,6 +9,8 @@ The changes have been made by the BCA Membership Administrator using the informa
 
 If they are incorrect please contact your club in the first instance or the BCA Membership Administrator ({$membership_admin_email}) otherwise.
 
+We may adjust your address in order to harmonize it with the post office address file.
+
 EOT;
 
 echo "\nNOW:-\n";


### PR DESCRIPTION
ISSUE: #3 
Periodically we may update addresses to match the Post Office's Address
File (PAF). This will generate a change of details email to registered
users. The changes are generally minor, for example moving the town to
the correct line. This needs explaining to the user so that they
understand and are not worried.

ACTION:
Add an explanatory sentence to the change of detail email.

NOTES:
When using services to bulk mail letters it is expected that the PAF
address will be used. People often use variations on the PAF address
which need to corrected. Incorrect address will cost us money since
the mailing provider will charge for them.

A better solution would be correct addresses at point of entry but we
can not do this since access to the PAF file is too expensive.

This applies to DIMs only since we do not bulk post mail to CIMs regularly.